### PR TITLE
DOCS: Fix delete response content everywhere

### DIFF
--- a/content/class-lab-resources.md
+++ b/content/class-lab-resources.md
@@ -275,11 +275,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 

--- a/content/classes.md
+++ b/content/classes.md
@@ -250,10 +250,8 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
 
 ### Usage

--- a/content/enrollments.md
+++ b/content/enrollments.md
@@ -243,11 +243,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 

--- a/content/events.md
+++ b/content/events.md
@@ -278,11 +278,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 

--- a/content/intro.md
+++ b/content/intro.md
@@ -84,7 +84,7 @@ We'll be adding additional authentication methods in the future.
 Each response, (except for `/health`) contains at the very least one high-level key (`result`) and two optional ones (`data` and `error`).
 
 <aside class="notice">
-Successful `DELETE` requests do not return a structured response, and instead return a 204 status code.
+Successful `DELETE` requests do not return a structured response, and instead return a 204 (No Content) status code.
 </aside>
 
 ### The `result` Key

--- a/content/ondemand.md
+++ b/content/ondemand.md
@@ -169,11 +169,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 

--- a/content/presentation-notes.md
+++ b/content/presentation-notes.md
@@ -125,11 +125,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 

--- a/content/presentations.md
+++ b/content/presentations.md
@@ -167,11 +167,10 @@ $ curl -X DELETE \
 
 > Response Example
 
-```json
-{
-  "result": "success"
-}
+```text
+204 No Content
 ```
+
 
 ### Usage
 


### PR DESCRIPTION
Our response to DELETE calls is actually not what's currently mentioned in the docs, but rather a 204. This is also stated in the intro, but then inconsistently reported in all other docs.  